### PR TITLE
fix: display label on multiselected items

### DIFF
--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -261,6 +261,7 @@ export const SelectOptionVirtualItem = memo<SelectOptionVirtualItemProps>(
         }}
         selected={item.selected}
         created={item.created}
+        label={item.label}
         {...rest}
       />
     )

--- a/src/use-select.ts
+++ b/src/use-select.ts
@@ -583,7 +583,7 @@ export function useSelect({
               (v: any) => getOption(v).value === selectedOption.value
             )
           ) {
-            ;(onChangeRef.current as any)?.([..._value, selectedOption.value], {
+            ;(onChangeRef.current as any)?.([..._value, selectedOption], {
               action: selectedOption.created
                 ? ChangeActions.MultiCreate
                 : ChangeActions.MultiSelect,


### PR DESCRIPTION
I made this fix to improve the selected options to display the label properly and to multiselected items hold the entire object instead the `value`. Also this prevents the `defaultGetOption` rewriting the label field to value.